### PR TITLE
Fix resample audio buffer bug

### DIFF
--- a/src/speech_to_text.cpp
+++ b/src/speech_to_text.cpp
@@ -24,7 +24,7 @@ uint32_t _resample_audio_buffer(
 
 		src_data.input_frames = p_src_frame_count;
 		src_data.src_ratio = (double)p_target_samplerate / (double)p_src_samplerate;
-		src_data.output_frames = int(p_src_frame_count*src_data.src_ratio);
+		src_data.output_frames = int(p_src_frame_count * src_data.src_ratio);
 
 		src_data.end_of_input = 0;
 		int error = src_simple(&src_data, SRC_SINC_BEST_QUALITY, 1);

--- a/src/speech_to_text.cpp
+++ b/src/speech_to_text.cpp
@@ -23,9 +23,9 @@ uint32_t _resample_audio_buffer(
 		src_data.data_out = p_dst;
 
 		src_data.input_frames = p_src_frame_count;
-		src_data.output_frames = p_src_frame_count;
-
 		src_data.src_ratio = (double)p_target_samplerate / (double)p_src_samplerate;
+		src_data.output_frames = int(p_src_frame_count*src_data.src_ratio);
+
 		src_data.end_of_input = 0;
 		int error = src_simple(&src_data, SRC_SINC_BEST_QUALITY, 1);
 		if (error != 0) {


### PR DESCRIPTION
hello, @fire @Ughuuu 

I have not tested whether this code has issues in the project because I encountered the problem of silent audio when using similar code in [ another project ](https://github.com/aiaimimi0920/godot-tts) 

The specific reason for the issue is that, according to this [documentation](http://www.mega-nerd.com/SRC/api_simple.html)

"output_frames" corresponds to the Maximum number of frames pointed to by "data_out."

For example, when resampling from 16000 to 48000, you may encounter long segments of silent audio later on. In such cases, you need to use this code:
`src_data.output_frames = int(p_src_frame_count * src_data.src_ratio);`
