### PR TITLE
Fix thread finish bug

### DIFF
--- a/src/speech_to_text.cpp
+++ b/src/speech_to_text.cpp
@@ -112,17 +112,20 @@ SpeechToText::SpeechToText() {
 }
 
 void SpeechToText::start_listen() {
-	if (is_running == false) {
-		is_running = true;
-		worker.start(Callable(this, StringName("run")), Thread::Priority::PRIORITY_NORMAL);
+	if (this->worker == nullptr) {
+		this->worker = memnew(Thread);
+	}
+	if (this->is_running == false) {
+		this->is_running = true;
+		this->worker->start(Callable(this, StringName("run")), Thread::Priority::PRIORITY_NORMAL);
 		t_last_iter = Time::get_singleton()->get_ticks_msec();
 	}
 }
 
 void SpeechToText::stop_listen() {
-	is_running = false;
-	if (worker.is_started()) {
-		worker.wait_to_finish();
+	this->is_running = false;
+	if (this->worker != nullptr) {
+		this->worker = nullptr;
 	}
 }
 

--- a/src/speech_to_text.h
+++ b/src/speech_to_text.h
@@ -183,7 +183,7 @@ public:
 	std::vector<float> s_queued_pcmf32;
 	std::vector<transcribed_msg> s_transcribed_msgs;
 	Mutex s_mutex; // for accessing shared variables from both main thread and worker thread
-	Thread worker;
+	Thread *worker = nullptr;
 	void run();
 
 	_FORCE_INLINE_ void set_entropy_threshold(float entropy_threshold) { params.entropy_threshold = entropy_threshold; }


### PR DESCRIPTION
worker.wait_to_finish() seems to trigger a crash.
But I don't know the reason.
If you click the stop button, you will test for a crash.

1. But I'm not sure if not calling "wait_to finish" can properly clean up the original thread object?


