### PR TITLE
Link with OpenCL by default and expose GNU extensions.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -14,6 +14,7 @@ env.Append(
         "WEBRTC_APM_DEBUG_DUMP=0",
         "WHISPER_BUILD",
         "GGML_BUILD",
+        "_GNU_SOURCE"
     ]
 )
 
@@ -74,6 +75,8 @@ else:
     opencl_library = os.environ.get('OpenCL_LIBRARY')
     if opencl_library:
         env.Append(LIBS=[opencl_library])
+    else:
+        env.Append(LIBS=["OpenCL"])
 
     clblast_sources = [
         "thirdparty/clblast/src/database/database.cpp",


### PR DESCRIPTION
This PR adds `_GNU_SOURCE` to the defines, matching what ggml has in its build system. Not having this defined results in a number of macros being taken up as implicitly-defined functions, which are then not found at runtime.

Additionally, `OpenCL` is added to the linked libraries unless overridden with `OpenCL_LIBRARY` in the environment variables. This fixes `clBuildProgram` not being resolved at runtime.

Fixes #73.